### PR TITLE
Fixed bug compiling assets when config/requirejs.yml is not present

### DIFF
--- a/lib/requirejs/rails/config.rb
+++ b/lib/requirejs/rails/config.rb
@@ -32,7 +32,7 @@ module Requirejs::Rails
 
       self.run_config = {
         "baseUrl" => "/assets",
-        "modules" => [ { name: 'application' } ]
+        "modules" => [ { 'name' => 'application' } ]
       }
       self.run_config.merge!(self.user_config)
       self.run_config_json = self.run_config.to_json
@@ -44,9 +44,9 @@ module Requirejs::Rails
     def module_path_for(name)
       self.target_dir+(name+'.js')
     end
-    
+
     def get_binding
       return binding()
-    end    
+    end
   end
 end


### PR DESCRIPTION
The default config hash was being created with a symbol as the index for the name field of the default module. This was breaking asset compilation when no config/requirejs.yml file was present because the rest of the library is expecting the hash index to be a string.
