### PR TITLE
Build environment init attempts production DB connection

### DIFF
--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -137,4 +137,10 @@ EOM
   end
 end
 
+task "assets:environment" do
+  # Ensure that require.js will be precompiled by Sprockets
+  if Rails.application.config.requirejs.loader == :requirejs
+    Rails.application.config.assets.precompile += %w( require.js )
+  end
+end
 task "assets:precompile" => ["requirejs:precompile:external"]


### PR DESCRIPTION
`rake assets:precompile` runs in the `production` environment by Rails 3 design.  Currently, rake tasks in this chain depend on the `environment` task, which does a full Rails app init.  This can cause issues like #29.  It is also troublesome if the production DB isn't reachable for whatever reason from the build environment, since it appears that ActiveRecord gets spun up and tries to initialize the DB connection. This causes the rake task to fail after a long-ish time trying to establish a connection.  Boo.

Ideally, the init sequence should be tweaked so that:
1. A minimum of Rails is fired up, especially for performance reasons.
2. The production DB is never referenced.

No. 1 is the "Holy Grail", but it may turn out to be impossible.  At very least, a dedicated Rails environment for the build will definitely fix no 2. and suffice to close this issue.
