### PR TITLE
Precompilation fails on Heroku

### DIFF
--- a/lib/requirejs/rails/engine.rb
+++ b/lib/requirejs/rails/engine.rb
@@ -23,26 +23,22 @@ module Requirejs
         end
       end
 
+      config.before_initialize do |app|
+        config = app.config
+        if ::Rails.env == "production"
+          config.assets.precompile += config.requirejs.precompile
+        end
+
+        manifest_path = File.join(::Rails.public_path, config.assets.prefix, "rjs_manifest.yml")
+        config.requirejs.manifest_path = Pathname.new(manifest_path)
+      end
+
       ### Initializers
       initializer "requirejs.tag_included_state" do |app|
         ActiveSupport.on_load(:action_controller) do
           ::ActionController::Base.class_eval do
             attr_accessor :requirejs_included
           end
-        end
-      end
-
-      initializer "requirejs.config" do |app|
-        config = app.config
-        if config.requirejs.manifest
-          path = File.join(config.assets.manifest, "rjs_manifest.yml")
-        else
-          path = File.join(::Rails.public_path, config.assets.prefix, "rjs_manifest.yml")
-        end
-        config.requirejs.manifest_path = Pathname.new(path)
-
-        if ::Rails.env == "production"
-          config.assets.precompile += config.requirejs.precompile
         end
       end
 


### PR DESCRIPTION
Hi,

Heroku requires this line for deployment: `config.assets.initialize_on_precompile = false`

It causes `rake assets:precompile` to fail. Here is the trace:

```
** Invoke assets:precompile (first_time)
** Invoke requirejs:precompile:stage1 (first_time)
** Invoke requirejs:test_node (first_time)
** Execute requirejs:test_node
** Invoke requirejs:precompile:prepare_source (first_time)
** Invoke requirejs:setup (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute requirejs:setup
** Invoke requirejs:clean (first_time)
** Invoke requirejs:setup 
** Execute requirejs:clean
** Invoke requirejs:assets:keep_js (first_time)
** Invoke requirejs:setup 
** Execute requirejs:assets:keep_js
** Execute requirejs:precompile:prepare_source
** Invoke requirejs:precompile:generate_rjs_driver (first_time)
** Invoke requirejs:setup 
** Execute requirejs:precompile:generate_rjs_driver
** Invoke requirejs:precompile:run_rjs (first_time)
** Invoke requirejs:setup 
** Invoke requirejs:test_node 
** Execute requirejs:precompile:run_rjs
** Execute requirejs:precompile:stage1
** Execute assets:precompile
/Users/kalema/.rvm/rubies/ruby-1.9.2-p290/bin/ruby /Users/kalema/.rvm/gems/ruby-1.9.2-p290/bin/rake assets:precompile:all RAILS_ENV=production RAILS_GROUPS=assets --trace
** Invoke assets:precompile:all (first_time)
** Execute assets:precompile:all
** Invoke assets:precompile:primary (first_time)
** Invoke assets:environment (first_time)
** Execute assets:environment
** Invoke tmp:cache:clear (first_time)
** Execute tmp:cache:clear
** Invoke requirejs:precompile:stage2 (first_time)
** Invoke requirejs:precompile:digestify_and_compress (first_time)
** Invoke requirejs:setup (first_time)
** Invoke environment (first_time)
** Execute environment
rake aborted!
Application has been already initialized.
~/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.1.3/lib/rails/application.rb:95:in `initialize!'
~/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.1.3/lib/rails/railtie/configurable.rb:30:in `method_missing'
~/Sites/Perso/Recruitee/Site/www_app/config/environment.rb:5:in `<top (required)>'
~/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.1.3/lib/active_support/dependencies.rb:240:in `require'
~/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.1.3/lib/active_support/dependencies.rb:240:in `block in require'
~/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.1.3/lib/active_support/dependencies.rb:225:in `load_dependency'
~/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.1.3/lib/active_support/dependencies.rb:240:in `require'
~/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.1.3/lib/rails/application.rb:83:in `require_environment!'
~/.rvm/gems/ruby-1.9.2-p290/gems/railties-3.1.3/lib/rails/application.rb:193:in `block (2 levels) in initialize_tasks'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `call'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `block in execute'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `each'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `execute'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:158:in `block in invoke_with_call_chain'
~/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/monitor.rb:201:in `mon_synchronize'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:176:in `block in invoke_prerequisites'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:174:in `each'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:174:in `invoke_prerequisites'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:157:in `block in invoke_with_call_chain'
~/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/monitor.rb:201:in `mon_synchronize'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:176:in `block in invoke_prerequisites'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:174:in `each'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:174:in `invoke_prerequisites'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:157:in `block in invoke_with_call_chain'
~/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/monitor.rb:201:in `mon_synchronize'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:176:in `block in invoke_prerequisites'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:174:in `each'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:174:in `invoke_prerequisites'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:157:in `block in invoke_with_call_chain'
~/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/monitor.rb:201:in `mon_synchronize'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:176:in `block in invoke_prerequisites'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:174:in `each'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:174:in `invoke_prerequisites'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:157:in `block in invoke_with_call_chain'
~/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/monitor.rb:201:in `mon_synchronize'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:144:in `invoke'
~/.rvm/gems/ruby-1.9.2-p290/gems/actionpack-3.1.3/lib/sprockets/assets.rake:56:in `block (3 levels) in <top (required)>'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `call'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `block in execute'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `each'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `execute'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:158:in `block in invoke_with_call_chain'
~/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/monitor.rb:201:in `mon_synchronize'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:144:in `invoke'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:116:in `invoke_task'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block (2 levels) in top_level'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `each'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block in top_level'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:88:in `top_level'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:66:in `block in run'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:63:in `run'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/bin/rake:33:in `<top (required)>'
~/.rvm/gems/ruby-1.9.2-p290/bin/rake:19:in `load'
~/.rvm/gems/ruby-1.9.2-p290/bin/rake:19:in `<main>'
Tasks: TOP => assets:precompile:primary => requirejs:precompile:stage2 => requirejs:precompile:digestify_and_compress => requirejs:setup => environment
rake aborted!
Command failed with status (1): [/Users/kalema/.rvm/rubies/ruby-1.9.2-p290/...]
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/file_utils.rb:53:in `block in create_shell_runner'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/file_utils.rb:45:in `call'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/file_utils.rb:45:in `sh'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/file_utils_ext.rb:39:in `sh'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/file_utils.rb:80:in `ruby'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/file_utils_ext.rb:39:in `ruby'
~/.rvm/gems/ruby-1.9.2-p290/gems/actionpack-3.1.3/lib/sprockets/assets.rake:9:in `ruby_rake_task'
~/.rvm/gems/ruby-1.9.2-p290/gems/requirejs-rails-0.5.3/lib/tasks/requirejs-rails_tasks.rake:46:in `invoke_or_reboot_rake_task'
~/.rvm/gems/ruby-1.9.2-p290/gems/actionpack-3.1.3/lib/sprockets/assets.rake:25:in `block (2 levels) in <top (required)>'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `call'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `block in execute'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `each'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `execute'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:158:in `block in invoke_with_call_chain'
~/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/monitor.rb:201:in `mon_synchronize'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/task.rb:144:in `invoke'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:116:in `invoke_task'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block (2 levels) in top_level'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `each'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block in top_level'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:88:in `top_level'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:66:in `block in run'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/lib/rake/application.rb:63:in `run'
~/.rvm/gems/ruby-1.9.2-p290/gems/rake-0.9.2.2/bin/rake:33:in `<top (required)>'
~/.rvm/gems/ruby-1.9.2-p290/bin/rake:19:in `load'
~/.rvm/gems/ruby-1.9.2-p290/bin/rake:19:in `<main>'
Tasks: TOP => assets:precompile
```
