### PR TITLE
Protect paths config with nil checks

### DIFF
--- a/app/helpers/requirejs_helper.rb
+++ b/app/helpers/requirejs_helper.rb
@@ -54,8 +54,10 @@ module RequirejsHelper
           paths = {}
           modules.each { |m| paths[m] = _javascript_path(m).sub /\.js$/,'' }
 
-          # Add paths for assets specified by full URL (on a CDN)
-          run_config['paths'].each { |k,v| paths[k] = v if v =~ /^https?:/ }
+          if run_config.has_key? 'paths'
+            # Add paths for assets specified by full URL (on a CDN)
+            run_config['paths'].each { |k,v| paths[k] = v if v =~ /^https?:/ }
+          end
 
           # Override user paths, whose mappings are only relevant in dev mode
           # and in the build_config.

--- a/test/requirejs-rails_test.rb
+++ b/test/requirejs-rails_test.rb
@@ -174,7 +174,7 @@ class RequirejsHelperTest < ActionView::TestCase
       Rails.application.config.assets.digest = true
       Rails.application.config.requirejs.user_config = { 'modules' => [{'name' => 'foo'}] }
       render :text => wrap(requirejs_include_tag)
-      assert_select "script:first-of-type", :text => %r{var require =.*paths.*http://ajax}
+      assert_select "script:first-of-type", :text => %r[var require =.*"paths":{"foo":"/javascripts/foo"}]
     ensure
       Rails.application.config.assets.digest = saved_digest
     end


### PR DESCRIPTION
If the config file doesn't define paths (or defines no items in it), the app crashes due to calling methods on nil.  I ran across:

```
ActionView::Template::Error
undefined method `each_with_object' for nil:NilClass
requirejs-rails (0.8.0) lib/requirejs/rails/config.rb:156:in `rewrite_urls_in_paths'

ActionView::Template::Error
undefined method `each' for nil:NilClass
requirejs-rails (0.8.0) app/helpers/requirejs_helper.rb:58:in `block in requirejs_include_tag'
```
