### PR TITLE
Avoid node crash during compilation

### DIFF
--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -107,7 +107,7 @@ EOM
                       "requirejs:test_node"] do
       requirejs.config.target_dir.mkpath
 
-      `node #{requirejs.config.driver_path}`
+      `node "#{requirejs.config.driver_path}"`
       unless $?.success?
         raise RuntimeError, "Asset compilation with node failed."
       end


### PR DESCRIPTION
In a very specific case (rjs_driver.js placed in a directory containing space chars in his name), node crashed because it couldn't find the file.
The fix is really simple but makes the compilation succeed !

This Pull Request is solving a problem seen in Issue #61.
