### PR TITLE
update link to AMD definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ discussed below.
 
 ### jQuery
 
-jQuery users must use jQuery 1.7 or later (`jquery-rails >= 1.0.17`) to use it as an [AMD module](http://wiki.commonjs.org/wiki/Modules/AsynchronousDefinition) with RequireJS.  To use jQuery in a module:
+jQuery users must use jQuery 1.7 or later (`jquery-rails >= 1.0.17`) to use it as an [AMD module](https://github.com/amdjs/amdjs-api/wiki/AMD) with RequireJS.  To use jQuery in a module:
 
 ```coffeescript
 # app/assets/javascripts/hello.js


### PR DESCRIPTION
The previous link was going to a document retained for historical purposes.
The current link is where the definitive API and definition is kept.
