### PR TITLE
Raise requirejs compilation errors and exit from node with code 1

### DIFF
--- a/lib/requirejs/rails/rjs_driver.js.erb
+++ b/lib/requirejs/rails/rjs_driver.js.erb
@@ -20,6 +20,12 @@ var module_specs = [
 <% end %>
 ];
 
+// Error handler invoked in case requirejs compilation fails
+var errback = function(error) {
+  process.stderr.write(error.toString());
+  process.exit(1);
+}
+
 // Do a series of builds of individual files, using the args suggested by:
 // http://requirejs.org/docs/optimization.html#onejs
 //
@@ -28,6 +34,7 @@ var module_specs = [
 var async_runner = module_specs.reduceRight(function(prev, curr) {
   return function (buildReportText) { 
     requirejs.optimize(mix(curr), prev);
+    requirejs.optimize(mix(curr), prev, errback);
   };
 }, function(buildReportText) {} );
 


### PR DESCRIPTION
This provides better feedback when errors are encountered instead of
raising the more dubious "Cannot compute digest for missing asset".
Addresses #108 #93
