### PR TITLE
Use a more accurate regex to determine which paths are CDN/external JavaScript files to include in require.paths

### DIFF
--- a/app/helpers/requirejs_helper.rb
+++ b/app/helpers/requirejs_helper.rb
@@ -49,8 +49,8 @@ module RequirejsHelper
           modules.each { |m| paths[m] = _javascript_path(m).sub /\.js$/,'' }
 
           if run_config.has_key? 'paths'
-            # Add paths for assets specified by full URL (on a CDN)
-            run_config['paths'].each { |k,v| paths[k] = v if v =~ /^https?:/ }
+            # Add paths for external assets (CDN URLs, etc.)
+            run_config['paths'].each { |k,v| paths[k] = v if v =~ %r{^(\w+:|//)} }
           end
 
           # Override user paths, whose mappings are only relevant in dev mode


### PR DESCRIPTION
Currently valid CDN paths like '//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js' are not output as part of require.paths when assets are precompiled.