### PR TITLE
Removed duplicate requirejs.optimize call

### DIFF
--- a/lib/requirejs/rails/rjs_driver.js.erb
+++ b/lib/requirejs/rails/rjs_driver.js.erb
@@ -33,7 +33,6 @@ var errback = function(error) {
 // builds.  Anticipating that need.
 var async_runner = module_specs.reduceRight(function(prev, curr) {
   return function (buildReportText) { 
-    requirejs.optimize(mix(curr), prev);
     requirejs.optimize(mix(curr), prev, errback);
   };
 }, function(buildReportText) {} );


### PR DESCRIPTION
No reason to call `requirejs.optimize` twice, and prefer it with an error callback.
