### PR TITLE
Fixes assets:precompile for new Rails 4 apps: fix Sprockets check

### DIFF
--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -32,7 +32,7 @@ namespace :requirejs do
   end
 
   task :setup => ["assets:environment"] do
-    unless Rails.application.config.assets.enabled
+    unless defined?(Sprockets)
       warn "Cannot precompile assets if sprockets is disabled. Please set config.assets.enabled to true"
       exit
     end


### PR DESCRIPTION
If you create a new Rails 4 app (rather than upgrade), `rake assets:precompile` will fail because `config.assets.enabled` was deprecated and is no longer set by default - thus evaluates to `nil`, triggering the guard clause in the diff.

The recommended way to disable asset pipeline is to remove the `sprockets-rails` gem, so I figured we can just check if `Sprockets` is defined.

Reference: http://yetimedia.tumblr.com/post/33320732456/moving-forward-with-the-rails-asset-pipeline
