### PR TITLE
supports rails' relative_url when building baseUrl for requirejs

### DIFF
--- a/app/helpers/requirejs_helper.rb
+++ b/app/helpers/requirejs_helper.rb
@@ -99,6 +99,6 @@ module RequirejsHelper
     js_asset_path = javascript_path(js_asset)
     uri = URI.parse(js_asset_path)
     asset_host = uri.host && js_asset_path.sub(uri.request_uri, '')
-    [asset_host, Rails.application.config.assets.prefix].join
+    [asset_host, Rails.application.config.relative_url_root, Rails.application.config.assets.prefix].join
   end
 end


### PR DESCRIPTION
Should baseUrl for requirejs honours rails relative_url_root?

In our project we've set Rails.application.config.relative_url_root so that asset_path generates a path sits under the relative_url_root. This was a workaround for us to use requirejs-rails gem with our setup.
