### PR TITLE
Actually disable js_compressor

### DIFF
--- a/lib/requirejs/rails/rjs_driver.js.erb
+++ b/lib/requirejs/rails/rjs_driver.js.erb
@@ -35,11 +35,10 @@ var errback = function(error) {
 // Do a series of builds of individual files, using the args suggested by:
 // http://requirejs.org/docs/optimization.html#onejs
 //
-// r.js will eventually need a nested call idiom to handle async 
+// r.js will eventually need a nested call idiom to handle async
 // builds.  Anticipating that need.
 var async_runner = module_specs.reduceRight(function(prev, curr) {
   return function (buildReportText) {
-    requirejs.optimize(mix(curr), prev);
     requirejs.optimize(mix(curr), prev, errback);
   };
 }, function(buildReportText) {} );

--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -86,7 +86,7 @@ OS X Homebrew users can use 'brew install node'.
       # after the environment ("config/application.rb",
       # "config/environments/*.rb") has been set up.
       Rails.application.config.assets.configure do |env|
-        env.js_compressor = false
+        env.js_compressor = nil
       end
     end
 


### PR DESCRIPTION
Setting `js_compressor = nil` will actually cause `uglifier` to be used inadvertently! Sprockets only [ignores the js_compressor](https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/sprockets/bootstrap.rb#L17-L19) when it is set to `false`.

Fixes #156 
