### PR TITLE
Fix invalid dir value in build config.

### DIFF
--- a/lib/requirejs/rails/rjs_driver.js.erb
+++ b/lib/requirejs/rails/rjs_driver.js.erb
@@ -5,7 +5,7 @@ var requirejs = require('<%= rjs_path %>'),
   baseConfig = <%=
     modifiedHash = build_config.select {|k, _| k != "modules"}
     pathsHash = modifiedHash["paths"]
-    modifiedHash["dir"] = self.target_dir
+    modifiedHash["dir"] = self.target_dir.to_s
     modifiedHash["paths"] = pathsHash.select {|_, v| !v.is_a?(Array)} if !pathsHash.nil?
 
     JSON.pretty_generate(modifiedHash)


### PR DESCRIPTION
Convert target_dir path config to a string to ensure json structure is valid. Closes #165.
