### PR TITLE
Allow defining functions in requirejs.yml

### DIFF
--- a/app/helpers/requirejs_helper.rb
+++ b/app/helpers/requirejs_helper.rb
@@ -59,8 +59,12 @@ module RequirejsHelper
         end
 
         run_config['baseUrl'] = base_url(name)
+        # Detect functions in JSON and unescape them so they can be evaluated by RequireJS
+        run_config_json = run_config.to_json.gsub(/"(function\(.*?\)\s*?{.*?}[\s\\n]*)"/) do |f|
+          eval(f).strip.delete("\n")
+        end
         html.concat <<-HTML
-        <script>var require = #{run_config.to_json};</script>
+        <script>var require = #{run_config_json};</script>
         HTML
       end
 


### PR DESCRIPTION
Some RequireJS config options such as init need a function, however
YAML and JSON can only store data - not JavaScript. As a workaround
this detects a function and unescapes it when the config is added
to the page in the helper.

Fixes #177
