### PR TITLE
Made it possible to use fallbacks for CDN paths

### DIFF
--- a/app/helpers/requirejs_helper.rb
+++ b/app/helpers/requirejs_helper.rb
@@ -56,7 +56,9 @@ module RequirejsHelper
 
           if run_config.has_key? 'paths'
             # Add paths for assets specified by full URL (on a CDN)
-            run_config['paths'].each { |k, v| paths[k] = v if v =~ /^https?:/ }
+            run_config['paths'].each do |k, v|
+              paths[k] = v if v.is_a?(Array) || v =~ /^https?:/
+            end
           end
 
           # Override user paths, whose mappings are only relevant in dev mode

--- a/lib/requirejs/rails/rjs_driver.js.erb
+++ b/lib/requirejs/rails/rjs_driver.js.erb
@@ -5,11 +5,9 @@ cdn_pattern = Regexp.new("\\Ahttps?://")
 modifiedHash = build_config.select { |k, _| k != "modules" }
 pathsHash = modifiedHash["paths"]
 modifiedHash["dir"] = build_dir.to_s
-modifiedHash["paths"] = Hash[pathsHash
-  .select do |_, v|
-    !v.is_a?(Array)
-  end.map do |k, v|
-    [k, if !cdn_pattern.match(v) then v else "empty:" end]
+modifiedHash["paths"] = Hash[
+  pathsHash.map do |k, v|
+    [k, v.is_a?(Array) || cdn_pattern.match(v) ? "empty:" : v]
   end
 ] if !pathsHash.nil?
 


### PR DESCRIPTION
With current behaviour, when arrays just removed from build_config it is impossible to use fallbacks paths, because r.js still looking for dependency module and precompilation fails with error "Error: ENOENT, no such file or directory ..."

With this changes configuration like this
config/requirejs.yml:

``` yaml
paths:
  jquery:
  - http://cdn1.com/jquery-1.9.1.min
  - http://cdn2.com/jquery-1.9.1.min
  - jquery-1.9.1
```

works as follows: replace paths array with "empty:" in build_config for such module
and adds this paths directly into run_config on page.
Make sure local fallback is precompiled on your server.
