### PR TITLE
Update requirejs_helper.rb

### DIFF
--- a/app/helpers/requirejs_helper.rb
+++ b/app/helpers/requirejs_helper.rb
@@ -35,6 +35,7 @@ module RequirejsHelper
 
     _once_guard do
       html.concat <<-HTML
+      <script>var require = {"baseUrl":"/assets"}</script>
       <script #{_requirejs_data(name, &block)} src="#{_javascript_path 'require.js'}"></script>
       HTML
 


### PR DESCRIPTION
Fixes #182 - Per the discussion in https://github.com/codeforamerica/ohana-web-search/issues/552, the baseUrl appears to be overwritten for module paths unless there is a baseUrl specified before loading the require.js file. I don't think this is probably the best solution, but this gets the discussion going and does solve the problem for our setup.
