### PR TITLE
Config paths for modules are not used in the digestify_and_compress task.

### DIFF
--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -144,7 +144,14 @@ OS X Homebrew users can use 'brew install node'.
     task digestify_and_compress: ["requirejs:setup"] do
       requirejs.config.build_config['modules'].each do |m|
         asset_name = "#{requirejs.config.module_name_for(m)}.js"
-        built_asset_path = requirejs.config.build_dir.join(asset_name)
+        asset_path_name = requirejs.config[:user_config]['paths'][requirejs.config.module_name_for(m)]
+
+        built_asset_path = if asset_path_name
+          requirejs.config.build_dir.join("#{asset_path_name}.js")
+        else
+          requirejs.config.build_dir.join(asset_name)
+        end
+
         digest_name = asset_name.sub(/\.(\w+)$/) { |ext| "-#{requirejs.builder.digest_for(built_asset_path)}#{ext}" }
         digest_asset_path = requirejs.config.target_dir + digest_name
 


### PR DESCRIPTION
Ash has the following configuration in `requirejs.yml`:

``` yaml
modules:
  - name: 'pokemons'
  - name: 'pikachu'
  - name: 'charizard'
paths:
  pikachi: 'monsters/pikachu'
  cahrizard: 'monsters/charizard'
```

Ash runs the `assets:precompile` task on his `pokemon` project, he gets an error:

```
Requirejs::BuildError: Cannot compute digest for missing asset: /home/ash/workspace/pokemon/tmp/requirejs/dst/pikachu
```

He expects that the `pikachu` and `charizard` modules are in `/home/ash/workspace/pokemon/tmp/requirejs/dst/monsters/pikachu` and `/home/ash/workspace/pokemon/tmp/requirejs/dst/monsters/charizard` respectively.
He suspects that the `digestify_and_compress` rake task is not using the `paths` in the config.
