### PR TITLE
Use config.assests.js_compressor setting for save original js compressor

### DIFF
--- a/lib/requirejs/rails/config.rb
+++ b/lib/requirejs/rails/config.rb
@@ -14,6 +14,7 @@ module Requirejs
       def initialize(application)
         super
         self.manifest = nil
+        self.js_compressor = nil
 
         self.logical_asset_filter = [/\.js$/, /\.html$/, /\.txt$/]
         self.tmp_dir = application.root + 'tmp'

--- a/lib/requirejs/rails/engine.rb
+++ b/lib/requirejs/rails/engine.rb
@@ -20,6 +20,8 @@ module Requirejs
 
         config.assets.precompile += config.requirejs.precompile
 
+        config.requirejs.js_compressor ||= config.assets.js_compressor
+
         # Check for the `requirejs:precompile:all` top-level Rake task and run the following initialization code.
         if defined?(Rake.application) && Rake.application.top_level_tasks == ["requirejs:precompile:all"]
           # Prevent Sprockets from freezing the assets environment, which allows JS compression to be toggled on a per-

--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -95,7 +95,7 @@ OS X Homebrew users can use 'brew install node'.
 
       # Save the original JS compressor and cache, which will be restored later.
 
-      original_js_compressor = Rails.application.config.assets.js_compressor
+      original_js_compressor = requirejs.config.js_compressor
       requirejs.env.js_compressor = false
 
       original_cache = requirejs.env.cache


### PR DESCRIPTION
When I set `config.assets.js_compressor` to compressor with some custom options like `Uglifier.new(mangle: false)`  
The precompile task always get the error: `Sprockets::Error: unknown compressor: js_compressor`, there's because Sprocket::Environment will return `:js_compressor` symbol when we want to get `Rails.application.assets.js_compressor` value if user set compressor to specific compressor object , please see https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/compressing.rb#L60

and when the task want to put `orignal_js_compressor` back to `env.js_compressor`, Sprocket can't find any compressor source name `:js_compressor` and throw error.

So it should be cache the `Rails.application.config.assets.js_compressor`(A real compressor object) to `original_js_compressor` not `Rails.application.assets.js_compressor`.

ref #201 
