### PR TITLE
Respect config.assets.prefix when generating assets

### DIFF
--- a/lib/requirejs/rails/engine.rb
+++ b/lib/requirejs/rails/engine.rb
@@ -36,9 +36,12 @@ module Requirejs
           end
         end
 
-        manifest_directory = config.assets.manifest || File.join(::Rails.public_path, config.assets.prefix)
+        target_dir = File.join(::Rails.public_path, config.assets.prefix)
+        manifest_directory = config.assets.manifest || target_dir
         manifest_path = File.join(manifest_directory, "rjs_manifest.yml")
+
         config.requirejs.manifest_path = Pathname.new(manifest_path)
+        config.requirejs.target_dir = Pathname.new(target_dir)
       end
 
       ### Initializers


### PR DESCRIPTION
I've updated the Rails engine to make use of `config.assets.prefix`. Previously, if I set the prefix, when running `rake assets:precompile`, the compiled JS files would be dumped into the default location (`public/assets`), and then it would fail complaining that it couldn't find the manifest in the correctly-prefixed location:

```
$ RAILS_ENV=production rake assets:precompile                                                     [16:26:13]
/Users/louis.simoneau/.rubies/ruby-2.2.0/bin/ruby ./bin/rake requirejs:precompile:all RAILS_ENV=production RAILS_GROUPS=assets
rake aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - /Users/louis.simoneau/rea/app/public/subdir/assets/rjs_manifest.yml
/Users/louis.simoneau/.gem/ruby/2.2.0/gems/requirejs-rails-0.9.8/lib/tasks/requirejs-rails_tasks.rake:179:in `initialize'
/Users/louis.simoneau/.gem/ruby/2.2.0/gems/requirejs-rails-0.9.8/lib/tasks/requirejs-rails_tasks.rake:179:in `open'
/Users/louis.simoneau/.gem/ruby/2.2.0/gems/requirejs-rails-0.9.8/lib/tasks/requirejs-rails_tasks.rake:179:in `open'
/Users/louis.simoneau/.gem/ruby/2.2.0/gems/requirejs-rails-0.9.8/lib/tasks/requirejs-rails_tasks.rake:179:in `block (4 levels) in <top (required)>'
/Users/louis.simoneau/.gem/ruby/2.2.0/gems/requirejs-rails-0.9.8/lib/tasks/requirejs-rails_tasks.rake:148:in `each'
/Users/louis.simoneau/.gem/ruby/2.2.0/gems/requirejs-rails-0.9.8/lib/tasks/requirejs-rails_tasks.rake:148:in `block (3 levels) in <top (required)>'
Tasks: TOP => requirejs:precompile:all => requirejs:precompile:digestify_and_compress
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [/Users/louis.simoneau/.rubies/ruby-2.2.0/b...]
/Users/louis.simoneau/.gem/ruby/2.2.0/gems/requirejs-rails-0.9.8/lib/tasks/requirejs-rails_tasks.rake:18:in `ruby_rake_task'
/Users/louis.simoneau/.gem/ruby/2.2.0/gems/requirejs-rails-0.9.8/lib/tasks/requirejs-rails_tasks.rake:85:in `block (3 levels) in <top (required)>'
Tasks: TOP => assets:precompile => requirejs:precompile:external
(See full trace by running task with --trace)
```