### PR TITLE
Generate the asset hash for a file based on its built contents, not t…

### DIFF
--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -160,7 +160,11 @@ OS X Homebrew users can use 'brew install node'.
         asset = requirejs.env.find_asset(asset_name)
 
         built_asset_path = requirejs.config.build_dir.join(asset_name)
-        digest_name = asset.digest_path
+
+        file_digest = ::Rails.application.assets.file_digest(built_asset_path)
+        hex_digest = Sprockets::DigestUtils.pack_hexdigest(file_digest)
+        digest_name = asset.logical_path.sub(/\.(\w+)$/) { |ext| "-#{hex_digest}#{ext}" }
+
         digest_asset_path = requirejs.config.target_dir + digest_name
 
         # Ensure that the parent directory `a/b` for modules with names like `a/b/c` exist.


### PR DESCRIPTION
…he static contents from sprockets.

---

In https://github.com/jwhitley/requirejs-rails/pull/217, @koenpunt switched to copying the built file to `asset.digest_path`. However, this is the digest of the original source file. If a dependency of one of the files changes, then the hash will remain the same. This causes massive problems with browsers not getting the new contents because the filename is the same and the browser pulls from cache.