### PR TITLE
On Precompile, transpile .es6 (ES6) extension to .js (ES5) by gem sprockets-es6

### DIFF
--- a/lib/requirejs/rails/config.rb
+++ b/lib/requirejs/rails/config.rb
@@ -16,6 +16,7 @@ module Requirejs
       LOGICAL_PATH_PATTERNS = [
           Regexp.new("\\.html\\z"),
           Regexp.new("\\.js\\z"),
+          Regexp.new("\\.es6\\z"),
           Regexp.new("\\.txt\\z"),
           BOWER_PATH_PATTERN
       ]

--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -100,7 +100,7 @@ OS X Homebrew users can use 'brew install node'.
 
       requirejs.env.each_logical_path(requirejs.config.logical_path_patterns) do |logical_path|
         m = ::Requirejs::Rails::Config::BOWER_PATH_PATTERN.match(logical_path)
-
+        binding.pry
         if !m
           asset = requirejs.env.find_asset(logical_path)
 

--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -97,13 +97,19 @@ OS X Homebrew users can use 'brew install node'.
 
       original_cache = requirejs.env.cache
       requirejs.env.cache = nil
-      binding.pry
 
       requirejs.env.each_logical_path(requirejs.config.logical_path_patterns) do |logical_path|
         m = ::Requirejs::Rails::Config::BOWER_PATH_PATTERN.match(logical_path)
         if !m
+          
+          # if file extension is .es6, change logical path extension to .js
+          check_extension = logical_path.split(".")
+          if check_extension[check_extension.length-1] == "es6"
+            check_extension[check_extension.length-1] = "js"
+            logical_path = check_extension.join(".")
+          end
+          
           asset = requirejs.env.find_asset(logical_path)
-          binding.pry
           if asset
             file = requirejs.config.source_dir.join(asset.logical_path)
             file.dirname.mkpath

--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -97,13 +97,13 @@ OS X Homebrew users can use 'brew install node'.
 
       original_cache = requirejs.env.cache
       requirejs.env.cache = nil
+      binding.pry
 
       requirejs.env.each_logical_path(requirejs.config.logical_path_patterns) do |logical_path|
         m = ::Requirejs::Rails::Config::BOWER_PATH_PATTERN.match(logical_path)
-        binding.pry
         if !m
           asset = requirejs.env.find_asset(logical_path)
-
+          binding.pry
           if asset
             file = requirejs.config.source_dir.join(asset.logical_path)
             file.dirname.mkpath


### PR DESCRIPTION
This PR works only if you already install gem `sprockets-es6`

Enable requirejs precompile to read .es6 file extension to logical path pattern.

On create temporary file to requirejs, read .es6 file extension as .js so sprockets will convert those ES6 scripts to ES5.