### PR TITLE
A small fix that makes requirejs-rails work with Sprockets 3.3.0

### DIFF
--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -162,7 +162,7 @@ OS X Homebrew users can use 'brew install node'.
         built_asset_path = requirejs.config.build_dir.join(asset_name)
 
         # Compute the digest based on the contents of the compiled file, *not* on the contents of the RequireJS module.
-        file_digest = ::Rails.application.assets.file_digest(built_asset_path)
+        file_digest = ::Rails.application.assets.file_digest(built_asset_path.to_s)
         hex_digest = Sprockets::DigestUtils.pack_hexdigest(file_digest)
         digest_name = asset.logical_path.gsub(path_extension_pattern) { |ext| "-#{hex_digest}#{ext}" }
 


### PR DESCRIPTION
Sprockets expects a String object (on which it calls #start_with?), not a Path for this call.