### PR TITLE
Digest file names should be strings, not pathnames

### DIFF
--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -162,7 +162,7 @@ OS X Homebrew users can use 'brew install node'.
         built_asset_path = requirejs.config.build_dir.join(asset_name)
 
         # Compute the digest based on the contents of the compiled file, *not* on the contents of the RequireJS module.
-        file_digest = ::Rails.application.assets.file_digest(built_asset_path.to_s)
+        file_digest = ::Rails.application.assets.file_digest(built_asset_path.to_s).to_s
         hex_digest = file_digest.unpack("H*").first
         digest_name = asset.logical_path.gsub(path_extension_pattern) { |ext| "-#{hex_digest}#{ext}" }
 


### PR DESCRIPTION
Currently, this fails when `file_digest` is a Pathname. To be sure it's a string (that can have `unpack` called on it, we should call `#to_s` on the `file_digest`.
