### PR TITLE
Add wrapShim to build_config_whitelist

### DIFF
--- a/lib/requirejs/rails/config.rb
+++ b/lib/requirejs/rails/config.rb
@@ -100,6 +100,7 @@ module Requirejs
         uglify2
         useStrict
         wrap
+        wrapShim
       }
       end
 


### PR DESCRIPTION
Allows using wrapShim in the build config (introduced in 2.1.11)

See: https://github.com/requirejs/r.js/blob/b8a6982d2923ae8389355edaa50d2b7f8065a01a/build/example.build.js#L68

As of 2.1.11, shimmed dependencies can be wrapped in a define() wrapper
to help when intermediate dependencies are AMD have dependencies of their
own. The canonical example is a project using Backbone, which depends on
jQuery and Underscore. Shimmed dependencies that want Backbone available
immediately will not see it in a build, since AMD compatible versions of
Backbone will not execute the define() function until dependencies are
ready. By wrapping those shimmed dependencies, this can be avoided, but
it could introduce other errors if those shimmed dependencies use the
global scope in weird ways, so it is not the default behavior to wrap.
More notes in http://requirejs.org/docs/api.html#config-shim