### PR TITLE
hex_digest can be a string or an Digest::MD5 object.

### DIFF
--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -151,7 +151,11 @@ OS X Homebrew users can use 'brew install node'.
 
         # Compute the digest based on the contents of the compiled file, *not* on the contents of the RequireJS module.
         file_digest = requirejs.env.file_digest(built_asset_path.to_s)
-        hex_digest = file_digest.unpack("H*").first
+        if file_digest.is_a? String
+          hex_digest = file_digest.unpack("H*").first
+        else
+          hex_digest = file_digest.hexdigest
+        end
         digest_name = asset.logical_path.gsub(path_extension_pattern) { |ext| "-#{hex_digest}#{ext}" }
 
         digest_asset_path = requirejs.config.target_dir + digest_name


### PR DESCRIPTION
Fixes #247