### PR TITLE
Don't raise Rake.application undefined in Rails >= 5.1

### DIFF
--- a/lib/requirejs/rails/engine.rb
+++ b/lib/requirejs/rails/engine.rb
@@ -57,7 +57,7 @@ module Requirejs
 
       # Are we running in the precompilation Rake task? If so, we need to adjust certain environmental configuration
       # values.
-      if defined?(Rake) && Rake.application.top_level_tasks.include?("requirejs:precompile:all")
+      if defined?(Rake.application) && Rake.application.top_level_tasks.include?("requirejs:precompile:all")
         initializer "requirejs.modify_environment_config", after: "load_environment_config", group: :all do |app|
           app.configure do
             # If we don't set this to true, sprockets-rails will assign `Rails.application.assets` to `nil`.


### PR DESCRIPTION
Fixes https://github.com/jwhitley/requirejs-rails/issues/276.

Rails 5.1.6 raises this error (stacktrace appended) during `rails server` boot if `requirejs-rails` is in the Gemfile.

May be related to:
https://github.com/rails/rails/issues/10628
https://github.com/jwhitley/requirejs-rails/blob/9008038db13f25e1c88224ceda9ab4d0ba7fd6b2/lib/requirejs/rails/engine.rb#L24

IMPORTANT:
To make this fix operational, you need to add `erubis` to `:test` group in your Gemfile.
This is because Rails >= 5.1 replaced `erubis` with `erubi`:
https://github.com/rails/rails/commit/7da8d76206271bdf200ea201f7e5a49afb9bc9e7
And `requirejs-rails` as of this writing still uses `erubis` for the generation of rjs driver:
https://github.com/jwhitley/requirejs-rails/blob/master/lib/requirejs/rails/builder.rb#L18
And in Rails < 5.1 `erubis` was required by `ActionView`:
https://github.com/jwhitley/requirejs-rails/blob/master/Gemfile.lock#L23

Stacktrace from my machine™:

```
~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:87:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'requirejs-rails'. (Bundler::GemRequireError)
Gem Load Error is: undefined method `application' for Rake:Module
Backtrace for gem load error is:
~/code/<my_namespace>/requirejs-rails/lib/requirejs/rails/engine.rb:63:in `<class:Engine>'
~/code/<my_namespace>/requirejs-rails/lib/requirejs/rails/engine.rb:9:in `<module:Rails>'
~/code/<my_namespace>/requirejs-rails/lib/requirejs/rails/engine.rb:8:in `<module:Requirejs>'
~/code/<my_namespace>/requirejs-rails/lib/requirejs/rails/engine.rb:7:in `<top (required)>'
~/.rvm/gems/ruby-2.4.0/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:292:in `require'
~/.rvm/gems/ruby-2.4.0/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:292:in `block in require'
~/.rvm/gems/ruby-2.4.0/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:258:in `load_dependency'
~/.rvm/gems/ruby-2.4.0/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:292:in `require'
~/code/<my_namespace>/requirejs-rails/lib/requirejs/rails.rb:3:in `<module:Rails>'
~/code/<my_namespace>/requirejs-rails/lib/requirejs/rails.rb:2:in `<module:Requirejs>'
~/code/<my_namespace>/requirejs-rails/lib/requirejs/rails.rb:1:in `<top (required)>'
~/.rvm/gems/ruby-2.4.0/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:292:in `require'
~/.rvm/gems/ruby-2.4.0/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:292:in `block in require'
~/.rvm/gems/ruby-2.4.0/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:258:in `load_dependency'
~/.rvm/gems/ruby-2.4.0/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:292:in `require'
~/code/<my_namespace>/requirejs-rails/lib/requirejs-rails.rb:3:in `<top (required)>'
~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:83:in `require'
~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:83:in `block (2 levels) in require'
~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:77:in `each'
~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:77:in `block in require'
~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:66:in `each'
~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:66:in `require'
~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler.rb:114:in `require'
~/code/<my_namespace>/<my_app>/config/application.rb:10:in `<top (required)>'
~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/commands/server/server_command.rb:133:in `require'
~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/commands/server/server_command.rb:133:in `block in perform'
~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/commands/server/server_command.rb:130:in `tap'
~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/commands/server/server_command.rb:130:in `perform'
~/.rvm/gems/ruby-2.4.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
~/.rvm/gems/ruby-2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
~/.rvm/gems/ruby-2.4.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/command/base.rb:63:in `perform'
~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/command.rb:44:in `invoke'
~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/commands.rb:16:in `<top (required)>'
bin/rails:5:in `require'
bin/rails:5:in `<main>'
Bundler Error Backtrace:
  from ~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
  from ~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:77:in `each'
  from ~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:77:in `block in require'
  from ~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:66:in `each'
  from ~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:66:in `require'
  from ~/.rvm/gems/ruby-2.4.0/gems/bundler-1.16.1/lib/bundler.rb:114:in `require'
  from ~/code/<my_namespace>/<my_app>/config/application.rb:10:in `<top (required)>'
  from ~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/commands/server/server_command.rb:133:in `require'
  from ~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/commands/server/server_command.rb:133:in `block in perform'
  from ~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/commands/server/server_command.rb:130:in `tap'
  from ~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/commands/server/server_command.rb:130:in `perform'
  from ~/.rvm/gems/ruby-2.4.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
  from ~/.rvm/gems/ruby-2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
  from ~/.rvm/gems/ruby-2.4.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
  from ~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/command/base.rb:63:in `perform'
  from ~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/command.rb:44:in `invoke'
  from ~/.rvm/gems/ruby-2.4.0/gems/railties-5.1.6/lib/rails/commands.rb:16:in `<top (required)>'
  from bin/rails:5:in `require'
  from bin/rails:5:in `<main>'
```