### PR TITLE
Ensure `Rake.respond_to?(application)` before access.

### DIFF
--- a/lib/requirejs/rails/engine.rb
+++ b/lib/requirejs/rails/engine.rb
@@ -61,7 +61,7 @@ module Requirejs
 
       # Are we running in the precompilation Rake task? If so, we need to adjust certain environmental configuration
       # values.
-      if defined?(Rake) && Rake.application.top_level_tasks.include?("requirejs:precompile:all")
+      if defined?(Rake) && Rake.respond_to?(:application) && Rake.application.top_level_tasks.include?("requirejs:precompile:all")
         initializer "requirejs.modify_environment_config", after: "load_environment_config", group: :all do |app|
           app.configure do
             # If we don't set this to true, sprockets-rails will assign `Rails.application.assets` to `nil`.


### PR DESCRIPTION
Apparently `Rake.application` may not be defined under all circumstances. This PR just adds a `respond_to?` check prior to access.

The following exception was raised attempting to run `rails s` in the development environment using ruby 2.5.6:

```
Traceback (most recent call last):
        46: from bin/rails:3:in `<main>'
        45: from bin/rails:3:in `load'
        44: from /home/svalentine/egear/egear-consumer/bin/spring:16:in `<top (required)>'
        43: from /home/svalentine/egear/egear-consumer/bin/spring:16:in `require'
        42: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/spring-2.1.0/lib/spring/binstub.rb:11:in `<top (required)>'
        41: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/spring-2.1.0/lib/spring/binstub.rb:11:in `load'
        40: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/spring-2.1.0/bin/spring:49:in `<top (required)>'
        39: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/spring-2.1.0/lib/spring/client.rb:30:in `run'
        38: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/spring-2.1.0/lib/spring/client/command.rb:7:in `call'
        37: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/spring-2.1.0/lib/spring/client/rails.rb:28:in `call'
        36: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/spring-2.1.0/lib/spring/client/rails.rb:28:in `load'
        35: from /home/svalentine/egear/egear-consumer/bin/rails:8:in `<top (required)>'
        34: from /home/svalentine/egear/egear-consumer/bin/rails:8:in `require'
        33: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/railties-5.2.3/lib/rails/commands.rb:18:in `<top (required)>'
        32: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/railties-5.2.3/lib/rails/command.rb:46:in `invoke'
        31: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/railties-5.2.3/lib/rails/command/base.rb:65:in `perform'
        30: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
        29: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
        28: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
        27: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/railties-5.2.3/lib/rails/commands/server/server_command.rb:142:in `perform'
        26: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/railties-5.2.3/lib/rails/commands/server/server_command.rb:142:in `tap'
        25: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/railties-5.2.3/lib/rails/commands/server/server_command.rb:145:in `block in perform'
        24: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/railties-5.2.3/lib/rails/commands/server/server_command.rb:145:in `require'
        23: from /home/svalentine/egear/egear-consumer/config/application.rb:7:in `<top (required)>'
        22: from /usr/share/rvm/rubies/ruby-2.5.6/lib/ruby/site_ruby/2.5.0/bundler.rb:114:in `require'
        21: from /usr/share/rvm/rubies/ruby-2.5.6/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:65:in `require'
        20: from /usr/share/rvm/rubies/ruby-2.5.6/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:65:in `each'
        19: from /usr/share/rvm/rubies/ruby-2.5.6/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:76:in `block in require'
        18: from /usr/share/rvm/rubies/ruby-2.5.6/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:76:in `each'
        17: from /usr/share/rvm/rubies/ruby-2.5.6/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:81:in `block (2 levels) in require'
        16: from /usr/share/rvm/rubies/ruby-2.5.6/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:81:in `require'
        15: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/requirejs-rails-1.0.1/lib/requirejs-rails.rb:1:in `<top (required)>'
        14: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
        13: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
        12: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
        11: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
        10: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/requirejs-rails-1.0.1/lib/requirejs/rails.rb:1:in `<top (required)>'
         9: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/requirejs-rails-1.0.1/lib/requirejs/rails.rb:2:in `<module:Requirejs>'
         8: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/requirejs-rails-1.0.1/lib/requirejs/rails.rb:3:in `<module:Rails>'
         7: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
         6: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
         5: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
         4: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
         3: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/requirejs-rails-1.0.1/lib/requirejs/rails/engine.rb:5:in `<top (required)>'
         2: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/requirejs-rails-1.0.1/lib/requirejs/rails/engine.rb:6:in `<module:Requirejs>'
         1: from /home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/requirejs-rails-1.0.1/lib/requirejs/rails/engine.rb:7:in `<module:Rails>'
/home/svalentine/.rvm/gems/ruby-2.5.6@egear-consumer/gems/requirejs-rails-1.0.1/lib/requirejs/rails/engine.rb:60:in `<class:Engine>': undefined method `application' for Rake:Module (NoMethodError)
```
