### PR TITLE
Build sprockets env

### DIFF
--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -186,4 +186,4 @@ OS X Homebrew users can use 'brew install node'.
   end
 end
 
-task "assets:precompile" => ["requirejs:precompile:external"]
+task "assets:precompile" => ["requirejs:precompile:all"]

--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -50,6 +50,8 @@ namespace :requirejs do
     _ = ActionView::Base
 
     requirejs.env = Rails.application.assets
+    # for build assets if the compile_assets is false in the current environment
+    requirejs.env ||= Sprockets::Railtie.build_environment(Rails.application, true)
 
     # Preserve the original asset paths, as we'll be manipulating them later
     requirejs.env_paths = requirejs.env.paths.dup

--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -188,4 +188,4 @@ OS X Homebrew users can use 'brew install node'.
   end
 end
 
-task "assets:precompile" => ["requirejs:precompile:all"]
+task "assets:precompile" => ["requirejs:precompile:external"]


### PR DESCRIPTION
use Sprockets::Railtie.build_environment(Rails.application, true) to build Rails.application.assets when it's nil